### PR TITLE
Use HTTPS for Debian backports source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN npm install -g renovate@${RENOVATE_VERSION} && \
 ENV GIT_VERSION=1:2.39.2-1~bpo11+1
 
 # Install from backports since renovate requires at least git 2.33.0
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" | tee /etc/apt/sources.list.d/bullseye-backports.list && \
+RUN echo "deb https://deb.debian.org/debian bullseye-backports main" | tee /etc/apt/sources.list.d/bullseye-backports.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends -t bullseye-backports git=${GIT_VERSION} && \
     apt-get clean && \


### PR DESCRIPTION
Use HTTPS instead of HTTP for Debian backports source