### PR TITLE
Revert "Ensure to not run script when installing package (#275)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y && \
 # renovate: datasource=npm depName=renovate
 ENV RENOVATE_VERSION=35.31.0
 
+# We need to run scripts here to have RE2 installed
 RUN npm install -g renovate@${RENOVATE_VERSION} && \
   npm cache clean --force && \
   # Smoke test

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -y && \
 # renovate: datasource=npm depName=renovate
 ENV RENOVATE_VERSION=35.31.0
 
-RUN npm install -g renovate@${RENOVATE_VERSION} --ignore-scripts && \
+RUN npm install -g renovate@${RENOVATE_VERSION} && \
   npm cache clean --force && \
   # Smoke test
   renovate --version


### PR DESCRIPTION
This reverts commit 1a5894ee6d52fcedd790dbc373b26673fb27783f to have RE2 available again in the image

Fixes #278