### PR TITLE
Downgrade to Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/swissgrc/azure-pipelines-node:22.5.1-net8 AS base
+FROM ghcr.io/swissgrc/azure-pipelines-node:20.16.0-net8 AS base
 
 FROM base AS build
 


### PR DESCRIPTION
Downgrade to Node 20 as this is required by Renovate 38.x.

In Renovate 37.x engine requirement was `^18.12.0 || >=20.0.0` which has been restricted to `^20.15.1` in 38.x.

Fixes #830 